### PR TITLE
fix concurrentMap typo in docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -75,7 +75,7 @@ The mapping function must return a promise. The result will be a new iterable wi
 the transformed values.
 
 ```javascript
-import { map } from "axax/es5/map";
+import { concurrentMap } from "axax/es5/concurrentMap";
 import { of } from "axax/es5/of";
 
 const mapped = concurrentMap(


### PR DESCRIPTION
I think there was a copy-paste mistake in the docs