### PR TITLE
Added new function 'first'

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -135,7 +135,7 @@ Take the first value of ansync iterable that fullfills the predicate. If not pre
 import { first } from "axax/es5/first";
 import { of } from "axax/es5/of";
 
-const firsted = filter(
+const firsted = first(
     value => value % 2 === 0
 )(of(1, 2, 3, 4, 5, 6));
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -139,7 +139,7 @@ const firsted = filter(
     value => value % 2 === 0
 )(of(1, 2, 3, 4, 5, 6));
 
-for await(const item of filtered) {
+for await(const item of firsted) {
     console.log(item); // outputs 2
 }
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,6 +6,7 @@
 - [map](#map)
 - [concurrentMap](#concurrentmap)
 - [filter](#filter)
+- [first](#first)
 - [flatMap](#flatmap)
 - [concat](#concat)
 - [reduce](#reduce)
@@ -123,6 +124,23 @@ const filtered = filter(
 
 for await(const item of filtered) {
     console.log(item); // outputs 2, 4, 6
+}
+```
+
+## first
+
+Take the first value of ansync iterable that fullfills the predicate. If not predicate is provided, it returns the first value of the async iterable.
+
+```javascript
+import { first } from "axax/es5/first";
+import { of } from "axax/es5/of";
+
+const firsted = filter(
+    value => value % 2 === 0
+)(of(1, 2, 3, 4, 5, 6));
+
+for await(const item of filtered) {
+    console.log(item); // outputs 2
 }
 ```
 

--- a/src/__tests__/first.test.ts
+++ b/src/__tests__/first.test.ts
@@ -1,0 +1,14 @@
+import { first } from "../first";
+import { of } from "../of";
+import { toArray } from "../toArray";
+
+test("first", async () => {
+  const result = await toArray(first()(of(1, 2, 3, 4, 5, 6)));
+  expect(result).toEqual([1]);
+});
+
+test("first with predicate", async () => {
+  const result = await toArray(
+      first((value: number) => value % 5 === 0)(of(1, 2, 3, 4, 5, 6)));
+  expect(result).toEqual([5]);
+});

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,0 +1,15 @@
+/**
+ * Take the first value or the first value to pass predicate from an async iterable
+ */
+export function first<T>(
+    predicate: (t: T) => boolean = () => true,
+) {
+    return async function* inner(source: AsyncIterable<T>) {
+        for await (const item of source) {
+            if (predicate(item)) {
+                yield item;
+                break;
+            }
+        }
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { insert } from "./insert";
 export { zip } from "./zip";
 export { toArray } from "./toArray";
 export { filter } from "./filter";
+export { first } from "./first";
 export { concat } from "./concat";
 export { fromEvent } from "./fromEvent";
 export { tap } from "./tap";


### PR DESCRIPTION
Adds the `first` function suggested in #20. Should be complete with tests and updated API documentation. Tests, linting and build seems to pass in `npm` (I don't use Yarn), but I'll happily fix any issues that I might have missed.