### PR TITLE
add the pluck operator

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -19,6 +19,7 @@
 - [scan](#scan)
 - [flatten](#flatten)
 - [pipe](#pipe)
+- [pluck] (#pluck)
 - [fromEvent](#fromevent)
 - [interval](#interval)
 - [sum](#sum)
@@ -366,6 +367,38 @@ const piped = pipe(
 for await(const item of piped) {
     console.log(item); // prints 4, 8
 }
+```
+
+## pluck
+
+Map source objects to a property specified by the given keys.
+Returns the unchanged source on empty input or undefined
+when any property in the path is undefined.
+
+```javascript
+import { from } from "axax/es5/from";
+import { pipe } from "axax/es5/pipe";
+import { pluck } from "axax/es5/pluck";
+
+const persons = [
+    {
+        name: "Anna",
+        age: 29,
+    },
+    {
+        name: "Max",
+        age: 41,
+    },
+]
+
+const piped = pipe(
+    pluck("name"))
+(from(persons));
+
+for await(const item of piped) {
+    console.log(item); // prints "Anna", "Max"
+}
+
 ```
 
 ## sum

--- a/src/__tests__/pluck.test.ts
+++ b/src/__tests__/pluck.test.ts
@@ -1,0 +1,95 @@
+import { from } from "../from";
+import { of } from "../of";
+import { pluck } from "../pluck";
+import { toArray } from "../toArray";
+
+test("pluck", async () => {
+  const source = {
+    a: "plucked",
+    x: 1,
+    y: 2,
+    z: {},
+  };
+
+  const result = await toArray(
+    pluck<typeof source, string>("a")(of(source))
+  );
+
+  expect(result).toEqual(["plucked"]);
+});
+
+test("pluck with multiple items", async () => {
+  const source = [
+    {
+      a: "item1",
+      x: 1,
+    },
+    {
+      a: "item2",
+      x: 1,
+    }
+  ];
+
+  const result = await toArray(
+    pluck<typeof source[0], string>("a")(from(source))
+  );
+
+  expect(result).toEqual(["item1", "item2"]);
+});
+
+test("pluck with nested properties", async () => {
+  const source = {
+    a: {
+      b: 1
+    },
+    x: 2,
+  };
+
+  const result = await toArray(
+    pluck<typeof source, number>("a", "b")(of(source))
+  );
+
+  expect(result).toEqual([1]);
+});
+
+test("pluck with undefined properties", async () => {
+  const source = {
+    a: {
+      b: 2
+    },
+    b: 3,
+    x: 4,
+  };
+
+  const result = await toArray(
+    pluck("a", "b", "c")(of(source))
+  );
+
+  expect(result).toEqual([undefined]);
+});
+
+test("pluck with no parameters", async () => {
+  const source = {
+    a: 1,
+  };
+
+  const result = await toArray(
+    pluck()(of(source))
+  );
+
+  expect(result).toEqual([source]);
+});
+
+test("pluck with non-object sources", async () => {
+  const source = [
+    1,
+    2,
+    4,
+  ];
+
+  const result = await toArray(
+    pluck("test")(of(source))
+  );
+
+  expect(result).toEqual([undefined]);
+});

--- a/src/pluck.ts
+++ b/src/pluck.ts
@@ -1,0 +1,18 @@
+/**
+ * Maps the source objects to their values at the path specified
+ */
+export function pluck<TFrom, TTo = any>(...path: string[]) {
+  return async function* inner(source: AsyncIterable<TFrom>) {
+    for await (const item of source) {
+      let value: any = item;
+      for (const key of path) {
+        if (value[key] === undefined) {
+          value = undefined;
+          break;
+        }
+        value = value[key];
+      }
+      yield value as TTo;
+    }
+  };
+}


### PR DESCRIPTION
Hi,

I added the pluck operator as described in #21, using a style that´s similar to the other operators in the module.

One thing I was unsure about were the type arguments for the `pluck` method. It doesn´t seem to be possible to infer the type of a nested object for an arbitrary path. So I let the `TTo` type argument default to any, enabling users to at least supply their own types. 
I would love some feedback on that to see if there´s a better way to infer the type of the plucked item.