### PR TITLE
generic

### DIFF
--- a/src/fromNodeStream.ts
+++ b/src/fromNodeStream.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import { Subject } from "./subject";
 
-export function fromNodeStream(stream: fs.ReadStream) {
-  const subject = new Subject<Buffer | string>();
+export function fromNodeStream<T = Buffer | string>(stream: fs.ReadStream) {
+  const subject = new Subject<T>();
 
-  stream.on("data", (chunk: Buffer | string) => subject.onNext(chunk));
+  stream.on("data", (chunk: T) => subject.onNext(chunk));
 
   stream.on("end", () => subject.onCompleted());
   stream.on("error", e => subject.onError(e));


### PR DESCRIPTION
## Description

Streams can be in string/buffer mode or object mode. In the latter mode, the data emitted from the stream could be any (except null), but currently fromNodeStream defines its iterator result type as <Buffer | string>.

For people who want to consume streams in object mode, and for correctness, since you don't know if the stream being passed in is in object mode or not, it should always use <any>.

## Issue

Issue #60

## Todos
- [x] Tests
- [x] API Documentation
