### PR TITLE
Properly close the underlying toCallback iterator

### DIFF
--- a/src/toCallbacks.ts
+++ b/src/toCallbacks.ts
@@ -16,8 +16,12 @@ export function toCallbacks<T>(
       const result = await iterator.next();
       try {
         await callback(result);
-      } catch (StopError) {
-        return;
+      } catch (err) {
+        if (err instanceof StopError) {
+          return iterator.return();
+        } else {
+          await iterator.throw(err);
+        }
       }
       if (result.done) {
         return;


### PR DESCRIPTION
```js
const a = async function * () { try { yield 1; yield 2; return 3 } finally { console.log('FIN') } }
const test = async () => {
  for await (const y of a()) {
    console.log(y) // logs '1'
    throw new Error('stop') // logs 'FIN'
  }
}
```

## Description
1- The typescript does not do class matching in catch clauses. `catch(StopError)` was not doing what was expected.
2- When using an underlying iterator, it must be closed properly to avoid memory leak.

## Issue
Not created one

## Todos
- [ ] Tests
- [x] API Documentation
